### PR TITLE
feat: adds optional sqs_region_override arg to broker

### DIFF
--- a/taskiq_sqs/broker.py
+++ b/taskiq_sqs/broker.py
@@ -36,6 +36,7 @@ class SQSBroker(AsyncBroker):
         max_number_of_messages: int = 1,  # size of batch to receive from the queue
         result_backend: Optional[AsyncResultBackend] = None,
         task_id_generator: Optional[Callable[[], str]] = None,
+        sqs_region_override: str | None = None,
     ) -> None:
         super().__init__(result_backend, task_id_generator)
 
@@ -43,7 +44,9 @@ class SQSBroker(AsyncBroker):
             raise BrokerError("A valid SQS Queue URL is required")
 
         self.sqs_queue_url = sqs_queue_url
-        self._sqs: SQSServiceResource = boto3.resource("sqs")
+        self._sqs: SQSServiceResource = boto3.resource(
+            "sqs", region_name=sqs_region_override
+        )
         self._sqs_queue: Optional[Queue] = None
 
         if max_number_of_messages > 10:

--- a/taskiq_sqs/broker.py
+++ b/taskiq_sqs/broker.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, AsyncGenerator, Callable, Optional, Union
 
 import boto3
 from asyncer import asyncify
-from botocore.config import Config
 from botocore.exceptions import ClientError
 from taskiq import AsyncBroker
 from taskiq.abc.result_backend import AsyncResultBackend
@@ -38,7 +37,6 @@ class SQSBroker(AsyncBroker):
         result_backend: Optional[AsyncResultBackend] = None,
         task_id_generator: Optional[Callable[[], str]] = None,
         sqs_region_override: str | None = None,
-        sqs_credentials_source_override: str | None = None,
     ) -> None:
         super().__init__(result_backend, task_id_generator)
 
@@ -47,10 +45,7 @@ class SQSBroker(AsyncBroker):
 
         self.sqs_queue_url = sqs_queue_url
         self._sqs: SQSServiceResource = boto3.resource(
-            "sqs",
-            config=Config(
-                region_name=sqs_region_override, credential_source=sqs_credentials_source_override
-            ),
+            "sqs", region_name=sqs_region_override
         )
         self._sqs_queue: Optional[Queue] = None
 
@@ -64,7 +59,9 @@ class SQSBroker(AsyncBroker):
         queue_name = self.sqs_queue_url.split("/")[-1]
 
         if not self._sqs_queue:
-            self._sqs_queue = await asyncify(self._sqs.get_queue_by_name)(QueueName=queue_name)
+            self._sqs_queue = await asyncify(self._sqs.get_queue_by_name)(
+                QueueName=queue_name
+            )
 
             if not self._sqs_queue:
                 raise Exception("SQS Queue not found")


### PR DESCRIPTION
Adds an optional `sqs_region_override` kwarg to the broker class  to force SQS queue to be used in a specific region that may be different from the environment.