### PR TITLE
feat: adds force_ecs_container_credentials kwarg to broker

### DIFF
--- a/taskiq_sqs/aws.py
+++ b/taskiq_sqs/aws.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+import urllib3  # boto3 peer dep (v1)
+
+ECS_CONTAINER_METADATA_URI = "http://169.254.170.2"
+
+
+class InvalidEnvironment(Exception):
+    pass
+
+
+def get_container_credentials():
+    """Fetches the ECS task role credentials provided by the metadata service"""
+    if not (relative_uri := os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")):
+        raise InvalidEnvironment(
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI not defined. This may not be an ECS container."
+        )
+
+    http = urllib3.PoolManager()
+    resp = http.request("GET", f"{ECS_CONTAINER_METADATA_URI}{relative_uri}")
+    return json.loads(resp.data)


### PR DESCRIPTION
Adds `force_ecs_container_credentials` kwarg to broker constructor that forces the broker to use ECS task role provided by the ECS metadata service. This bypasses boto3's normal order of ops for figuring out which credentials to use, by going straight to the metadata service.